### PR TITLE
fix post_type-check in add-meta-boxes hook

### DIFF
--- a/includes/admin/metaboxes.php
+++ b/includes/admin/metaboxes.php
@@ -60,7 +60,7 @@ class Envira_Gallery_Metaboxes {
         add_action( 'wp_print_scripts', array( $this, 'fix_plugin_js_conflicts' ), 100 );
 
         // Metaboxes
-        add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 1 );
+        add_action( 'add_meta_boxes_envira', array( $this, 'add_meta_boxes' ), 1 );
 
         // Add the envira-gallery class to the form, so our styles can be applied
         add_action( 'post_edit_form_tag', array( $this, 'add_form_class' ) );


### PR DESCRIPTION
When comment is edit hook 'add_meta_boxes' is fires but global variable `$post = null `. In [Codex](https://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes) says:

>  You can also use add_meta_boxes_{post_type} for best practice, so your hook will only run when editing a specific post type. 

To avoid check post _type in callback.  My lucky :smile: #13 issue.  